### PR TITLE
Stop PK API client from modifying root logger

### DIFF
--- a/placekey/api.py
+++ b/placekey/api.py
@@ -10,7 +10,7 @@ console_log = logging.StreamHandler()
 console_log.setFormatter(
     logging.Formatter('%(asctime)s\t%(levelname)s\t%(message)s')
 )
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)
 log.handlers = [console_log]
 


### PR DESCRIPTION
Previously, importing the placekey module would cause it to immediately
suppress all but logging.ERROR logs in any code that it is imported
into. This is somewhat unexpected since you'd expect that importing a
module doesn't have side-effects on the rest of your program.

This makes it so that the logging settings in this module apply to this
module.