### PR TITLE
Fix placekey_format_is_valid() function for invalid placekey

### DIFF
--- a/placekey/placekey.py
+++ b/placekey/placekey.py
@@ -335,7 +335,10 @@ def placekey_format_is_valid(placekey):
     :return: True if the Placekey is valid, False otherwise
 
     """
-    what, where = _parse_placekey(placekey)
+    try:
+        what, where = _parse_placekey(placekey)
+    except ValueError:
+        return False
 
     if what:
         return _where_part_is_valid(where) and bool(WHAT_REGEX.match(what))

--- a/placekey/tests/test_placekey.py
+++ b/placekey/tests/test_placekey.py
@@ -240,6 +240,7 @@ class TestPlacekey(unittest.TestCase):
                          'short poi encoding')
 
         self.assertFalse(pk.placekey_format_is_valid('@abc-234-xyz'), 'invalid where value')
+        self.assertFalse(pk.placekey_format_is_valid('@@abc-234-xyz'), 'multiple @ in placekey')
 
     def test_where_part_is_valid(self):
         """


### PR DESCRIPTION
`placekey_format_is_valid()` function throws a `ValueError` when a bad placekey contains multiple `@` symbols

This MR fixes that issue.