### PR TITLE
Not sure why, but this makes it work with pyinstaller

### DIFF
--- a/placekey/api.py
+++ b/placekey/api.py
@@ -4,7 +4,7 @@ import itertools
 import requests
 from ratelimit import limits, RateLimitException
 from backoff import on_exception, fibo
-from .__init__ import __version__
+from .__version__ import __version__
 
 console_log = logging.StreamHandler()
 console_log.setFormatter(


### PR DESCRIPTION
First let me say how cool this whole project is! I think you guys doing a really good thing by trying to introduce a cleaner form of location matching. It was really easy to get an api key and get started, and it's awesome that using the API is free in general! 

I had no problems using this package directly, but when trying to run a PyInstaller built executable I was getting this
```
    from placekey.api import PlacekeyAPI
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "placekey/api.py", line 7, in <module>
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "placekey/__init__.py", line 1, in <module>
ModuleNotFoundError: No module named 'placekey.__init__.placekey'
```
which I assume has to do with the oddities of PYTHONPATH or something 🤷 . I attempted to add many different combinations of things as PyInstaller hidden-imports to no avail. However, changing this allows it to run successfully, and doesn't seem like it will break anything else. Since the change seems innocuous, and fixes an issue for me and maybe others I figured I'd open this PR. 

Thanks for your time!