### PR TITLE
Updates to API

### DIFF
--- a/placekey/tests/test_api.py
+++ b/placekey/tests/test_api.py
@@ -44,11 +44,12 @@ class TestAPI(unittest.TestCase):
             "city": "San Francisco",
             "region": "CA",
             "postal_code": "94131",
-            "iso_country_code": "US"
+            "iso_country_code": "US",
+            "place_metadata": {"naics_code": "45115"}
         }
         self.assertDictEqual(
-            self.pk_api.lookup_placekey(**place, strict_address_match=True),
-            {'query_id': '0', 'placekey': '227@5vg-82n-pgk'}
+            self.pk_api.lookup_placekey(**place, fields=["address_placekey"]),
+            {'query_id': '0', 'placekey': '227@5vg-82n-pgk', 'address_placekey': '227@5vg-82n-pgk'}
         )
 
         # An invalid query


### PR DESCRIPTION
# Function Changes
- strict matching no longer has support on latest version of Placekey api. By this, the strict matching params (strict_address_match, strict_name_match) have been removed form the calling functions. 
- Placekey api now supports alternate placekey types: address and building placekeys; more can be found in the documentation but these values can be retrieved by passing them in the fields param. Note, a placekey will always be returned and does not need to be passed. 
- Added support of place_metadata a dict[str,str] providing a location for the passing of store_id, phone_number, website, naics_code and mcc_code to the api.  